### PR TITLE
RAM-backed Postgres powered by Testcontainers with tmpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,296 @@
+## Ubuntu 24.04 (Yandex Cloud)
+
+```shell
+go test -timeout=30m -p=1 -count=5 ./...
+?       github.com/ivagulin/dbmocks/migrations  [no test files]
+ok      github.com/ivagulin/dbmocks/pgtestpkg   109.782s
+?       github.com/ivagulin/dbmocks/repo        [no test files]
+ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        104.616s
+ok      github.com/ivagulin/dbmocks/testcontainerspkg   432.450s
+?       github.com/ivagulin/dbmocks/testinfra   [no test files]
+
+go test -timeout=30m -p=1 -count=3 ./...
+?       github.com/ivagulin/dbmocks/migrations  [no test files]
+ok      github.com/ivagulin/dbmocks/pgtestpkg   65.956s
+?       github.com/ivagulin/dbmocks/repo        [no test files]
+ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        63.031s
+ok      github.com/ivagulin/dbmocks/testcontainerspkg   262.272s
+?       github.com/ivagulin/dbmocks/testinfra   [no test files]
+```
+
+### Окружение
+
+Yandex Cloud:
+
+- OS: Ubuntu 24.04
+- CPU: 16 CPU 100%, Intel Ice Lake
+- RAM: 32 GiB
+- DISK: SSD IO 186 GB (56000/11200 IOPS, 220/164 MB/s)
+
+<details>
+
+<summary>Подробнее</summary>
+
+```shell
+lsb_release -a
+No LSB modules are available.
+Distributor ID: Ubuntu
+Description:    Ubuntu 24.04.2 LTS
+Release:        24.04
+Codename:       noble
+
+lscpu
+Architecture:             x86_64
+  CPU op-mode(s):         32-bit, 64-bit
+  Address sizes:          40 bits physical, 57 bits virtual
+  Byte Order:             Little Endian
+CPU(s):                   16
+  On-line CPU(s) list:    0-15
+Vendor ID:                GenuineIntel
+  BIOS Vendor ID:         QEMU
+  Model name:             Intel Xeon Processor (Icelake)
+    BIOS Model name:      pc-q35-yc-2.12  CPU @ 2.0GHz
+    BIOS CPU family:      1
+    CPU family:           6
+    Model:                106
+    Thread(s) per core:   2
+    Core(s) per socket:   8
+    Socket(s):            1
+    Stepping:             0
+    BogoMIPS:             3990.63
+    Flags:                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma 
+                          cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault ssbd ibrs ibpb stibp ibrs_enhanced fsgsbase bmi1 avx2 smep bmi2 erms invpcid avx512f a
+                          vx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 wbnoinvd arat avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntd
+                          q la57 rdpid fsrm md_clear arch_capabilities
+Virtualization features:  
+  Hypervisor vendor:      KVM
+  Virtualization type:    full
+Caches (sum of all):      
+  L1d:                    512 KiB (16 instances)
+  L1i:                    512 KiB (16 instances)
+  L2:                     32 MiB (8 instances)
+  L3:                     16 MiB (1 instance)
+NUMA:                     
+  NUMA node(s):           1
+  NUMA node0 CPU(s):      0-15
+Vulnerabilities:          
+  Gather data sampling:   Not affected
+  Itlb multihit:          Not affected
+  L1tf:                   Not affected
+  Mds:                    Not affected
+  Meltdown:               Not affected
+  Mmio stale data:        Mitigation; Clear CPU buffers; SMT Host state unknown
+  Reg file data sampling: Not affected
+  Retbleed:               Not affected
+  Spec rstack overflow:   Not affected
+  Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
+  Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+  Spectre v2:             Mitigation; Enhanced / Automatic IBRS; IBPB conditional; RSB filling; PBRSB-eIBRS SW sequence; BHI SW loop, KVM SW loop
+  Srbds:                  Not affected
+  Tsx async abort:        Not affected
+  
+free -h
+               total        used        free      shared  buff/cache   available
+Mem:            31Gi       1.3Gi        26Gi       182Mi       4.7Gi        30Gi
+Swap:             0B          0B          0B
+
+go version
+go version go1.23.10 linux/amd64
+
+docker info
+Client: Docker Engine - Community
+ Version:    28.3.1
+ Context:    default
+ Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc.)
+    Version:  v0.25.0
+    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+  compose: Docker Compose (Docker Inc.)
+    Version:  v2.38.1
+    Path:     /usr/libexec/docker/cli-plugins/docker-compose
+
+Server:
+ Containers: 0
+  Running: 0
+  Paused: 0
+  Stopped: 0
+ Images: 2
+ Server Version: 28.3.1
+ Storage Driver: overlay2
+  Backing Filesystem: extfs
+  Supports d_type: true
+  Using metacopy: false
+  Native Overlay Diff: true
+  userxattr: false
+ Logging Driver: json-file
+ Cgroup Driver: systemd
+ Cgroup Version: 2
+ Plugins:
+  Volume: local
+  Network: bridge host ipvlan macvlan null overlay
+  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
+ CDI spec directories:
+  /etc/cdi
+  /var/run/cdi
+ Swarm: inactive
+ Runtimes: io.containerd.runc.v2 runc
+ Default Runtime: runc
+ Init Binary: docker-init
+ containerd version: 05044ec0a9a75232cad458027ca83437aae3f4da
+ runc version: v1.2.5-0-g59923ef
+ init version: de40ad0
+ Security Options:
+  apparmor
+  seccomp
+   Profile: builtin
+  cgroupns
+ Kernel Version: 6.8.0-62-generic
+ Operating System: Ubuntu 24.04.2 LTS
+ OSType: linux
+ Architecture: x86_64
+ CPUs: 16
+ Total Memory: 31.34GiB
+ Name: compute-vm-16-32-186-ssd-io-m3-1751676682773
+ ID: 9bac4856-d65a-42b6-9048-367a314948d6
+ Docker Root Dir: /var/lib/docker
+ Debug Mode: false
+ Experimental: false
+ Insecure Registries:
+  ::1/128
+  127.0.0.0/8
+ Live Restore Enabled: false
+ 
+psql --version
+psql (PostgreSQL) 16.9 (Ubuntu 16.9-1.pgdg24.04+1)
+
+docker images | grep postgres
+postgres              16        f465f4fe2ba0   4 weeks ago    436MB
+```
+
+</details>
+
+<details>
+
+<summary>Настройка окружения</summary>
+
+```shell
+sudo apt update
+sudo apt install -y \
+  git \
+  wget \
+  curl \
+  ca-certificates \
+  gnupg \
+  lsb-release \
+  apt-transport-https
+
+#go
+rm -rf /usr/local/go
+wget https://go.dev/dl/go1.23.10.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.23.10.linux-amd64.tar.gz
+
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+source ~/.profile
+
+go version
+
+#docker
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+docker pull postgres:16
+
+#postgres
+sudo apt install -y postgresql-common curl ca-certificates
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+
+sudo apt update
+sudo apt install -y postgresql-16 postgresql-client-16 libpq-dev
+
+psql --version
+```
+
+</details>
+
+## MacOS
+
+```shell
+go test -timeout=30m -p=1 -count=3 ./...
+?       github.com/ivagulin/dbmocks/migrations  [no test files]
+ok      github.com/ivagulin/dbmocks/pgtestpkg   179.647s
+?       github.com/ivagulin/dbmocks/repo        [no test files]
+ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        100.401s
+ok      github.com/ivagulin/dbmocks/testcontainerspkg   112.284s
+?       github.com/ivagulin/dbmocks/testinfra   [no test files]
+
+go test -timeout=30m -p=1 -count=3 ./...
+?       github.com/ivagulin/dbmocks/migrations  [no test files]
+ok      github.com/ivagulin/dbmocks/pgtestpkg   179.349s
+?       github.com/ivagulin/dbmocks/repo        [no test files]
+ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        106.758s
+ok      github.com/ivagulin/dbmocks/testcontainerspkg   117.221s
+?       github.com/ivagulin/dbmocks/testinfra   [no test files]
+```
+
+### Окружение
+
+Apple MacBook Pro 14, M2 Pro, 32 GiB, 512 GB, macOS 13.7.4 (22H420)
+
+<details>
+
+<summary>Подробнее</summary>
+
+```shell
+go version
+go version go1.23.5 darwin/arm64
+
+docker version
+Client:
+ Version:           28.0.1
+ API version:       1.48
+ Go version:        go1.23.6
+ Git commit:        068a01e
+ Built:             Wed Feb 26 10:38:16 2025
+ OS/Arch:           darwin/arm64
+ Context:           desktop-linux
+
+Server: Docker Desktop 4.39.0 (184744)
+ Engine:
+  Version:          28.0.1
+  API version:      1.48 (minimum version 1.24)
+  Go version:       go1.23.6
+  Git commit:       bbd0a17
+  Built:            Wed Feb 26 10:40:57 2025
+  OS/Arch:          linux/arm64
+  Experimental:     false
+ containerd:
+  Version:          1.7.25
+  GitCommit:        bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
+ runc:
+  Version:          1.2.4
+  GitCommit:        v1.2.4-0-g6c52b3f
+ docker-init:
+  Version:          0.19.0
+  GitCommit:        de40ad0
+  
+postgres --version
+postgres (PostgreSQL) 16.9 (Homebrew)
+```
+
+</details>

--- a/testcontainers_tmpfs/base.go
+++ b/testcontainers_tmpfs/base.go
@@ -1,4 +1,4 @@
-package pgtestpkg
+package testcontainers_tmpfs
 
 import (
 	"github.com/ivagulin/dbmocks/testinfra"
@@ -11,7 +11,7 @@ type SuiteBase struct {
 }
 
 func (s *SuiteBase) SetupSuite() {
-	s.gDB = testinfra.MustStartDB(s.T(), false)
+	s.gDB = testinfra.MustStartDB(s.T(), true)
 }
 
 func (s *SuiteBase) TearDownSuite() {

--- a/testcontainers_tmpfs/gen.sh
+++ b/testcontainers_tmpfs/gen.sh
@@ -1,0 +1,1 @@
+for i in `seq -w 1 100`; do sed "s/Suite1/Suite$i/g" template_test.go > suite"$i"_test.go ; done

--- a/testcontainers_tmpfs/suite001_test.go
+++ b/testcontainers_tmpfs/suite001_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite001 struct {
+	SuiteBase
+}
+
+func (s *Suite001) TestFunc1()  {}
+func (s *Suite001) TestFunc2()  {}
+func (s *Suite001) TestFunc3()  {}
+func (s *Suite001) TestFunc4()  {}
+func (s *Suite001) TestFunc5()  {}
+func (s *Suite001) TestFunc6()  {}
+func (s *Suite001) TestFunc7()  {}
+func (s *Suite001) TestFunc8()  {}
+func (s *Suite001) TestFunc9()  {}
+func (s *Suite001) TestFunc10() {}
+
+func TestSuite001(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite001))
+}

--- a/testcontainers_tmpfs/suite002_test.go
+++ b/testcontainers_tmpfs/suite002_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite002 struct {
+	SuiteBase
+}
+
+func (s *Suite002) TestFunc1()  {}
+func (s *Suite002) TestFunc2()  {}
+func (s *Suite002) TestFunc3()  {}
+func (s *Suite002) TestFunc4()  {}
+func (s *Suite002) TestFunc5()  {}
+func (s *Suite002) TestFunc6()  {}
+func (s *Suite002) TestFunc7()  {}
+func (s *Suite002) TestFunc8()  {}
+func (s *Suite002) TestFunc9()  {}
+func (s *Suite002) TestFunc10() {}
+
+func TestSuite002(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite002))
+}

--- a/testcontainers_tmpfs/suite003_test.go
+++ b/testcontainers_tmpfs/suite003_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite003 struct {
+	SuiteBase
+}
+
+func (s *Suite003) TestFunc1()  {}
+func (s *Suite003) TestFunc2()  {}
+func (s *Suite003) TestFunc3()  {}
+func (s *Suite003) TestFunc4()  {}
+func (s *Suite003) TestFunc5()  {}
+func (s *Suite003) TestFunc6()  {}
+func (s *Suite003) TestFunc7()  {}
+func (s *Suite003) TestFunc8()  {}
+func (s *Suite003) TestFunc9()  {}
+func (s *Suite003) TestFunc10() {}
+
+func TestSuite003(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite003))
+}

--- a/testcontainers_tmpfs/suite004_test.go
+++ b/testcontainers_tmpfs/suite004_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite004 struct {
+	SuiteBase
+}
+
+func (s *Suite004) TestFunc1()  {}
+func (s *Suite004) TestFunc2()  {}
+func (s *Suite004) TestFunc3()  {}
+func (s *Suite004) TestFunc4()  {}
+func (s *Suite004) TestFunc5()  {}
+func (s *Suite004) TestFunc6()  {}
+func (s *Suite004) TestFunc7()  {}
+func (s *Suite004) TestFunc8()  {}
+func (s *Suite004) TestFunc9()  {}
+func (s *Suite004) TestFunc10() {}
+
+func TestSuite004(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite004))
+}

--- a/testcontainers_tmpfs/suite005_test.go
+++ b/testcontainers_tmpfs/suite005_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite005 struct {
+	SuiteBase
+}
+
+func (s *Suite005) TestFunc1()  {}
+func (s *Suite005) TestFunc2()  {}
+func (s *Suite005) TestFunc3()  {}
+func (s *Suite005) TestFunc4()  {}
+func (s *Suite005) TestFunc5()  {}
+func (s *Suite005) TestFunc6()  {}
+func (s *Suite005) TestFunc7()  {}
+func (s *Suite005) TestFunc8()  {}
+func (s *Suite005) TestFunc9()  {}
+func (s *Suite005) TestFunc10() {}
+
+func TestSuite005(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite005))
+}

--- a/testcontainers_tmpfs/suite006_test.go
+++ b/testcontainers_tmpfs/suite006_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite006 struct {
+	SuiteBase
+}
+
+func (s *Suite006) TestFunc1()  {}
+func (s *Suite006) TestFunc2()  {}
+func (s *Suite006) TestFunc3()  {}
+func (s *Suite006) TestFunc4()  {}
+func (s *Suite006) TestFunc5()  {}
+func (s *Suite006) TestFunc6()  {}
+func (s *Suite006) TestFunc7()  {}
+func (s *Suite006) TestFunc8()  {}
+func (s *Suite006) TestFunc9()  {}
+func (s *Suite006) TestFunc10() {}
+
+func TestSuite006(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite006))
+}

--- a/testcontainers_tmpfs/suite007_test.go
+++ b/testcontainers_tmpfs/suite007_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite007 struct {
+	SuiteBase
+}
+
+func (s *Suite007) TestFunc1()  {}
+func (s *Suite007) TestFunc2()  {}
+func (s *Suite007) TestFunc3()  {}
+func (s *Suite007) TestFunc4()  {}
+func (s *Suite007) TestFunc5()  {}
+func (s *Suite007) TestFunc6()  {}
+func (s *Suite007) TestFunc7()  {}
+func (s *Suite007) TestFunc8()  {}
+func (s *Suite007) TestFunc9()  {}
+func (s *Suite007) TestFunc10() {}
+
+func TestSuite007(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite007))
+}

--- a/testcontainers_tmpfs/suite008_test.go
+++ b/testcontainers_tmpfs/suite008_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite008 struct {
+	SuiteBase
+}
+
+func (s *Suite008) TestFunc1()  {}
+func (s *Suite008) TestFunc2()  {}
+func (s *Suite008) TestFunc3()  {}
+func (s *Suite008) TestFunc4()  {}
+func (s *Suite008) TestFunc5()  {}
+func (s *Suite008) TestFunc6()  {}
+func (s *Suite008) TestFunc7()  {}
+func (s *Suite008) TestFunc8()  {}
+func (s *Suite008) TestFunc9()  {}
+func (s *Suite008) TestFunc10() {}
+
+func TestSuite008(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite008))
+}

--- a/testcontainers_tmpfs/suite009_test.go
+++ b/testcontainers_tmpfs/suite009_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite009 struct {
+	SuiteBase
+}
+
+func (s *Suite009) TestFunc1()  {}
+func (s *Suite009) TestFunc2()  {}
+func (s *Suite009) TestFunc3()  {}
+func (s *Suite009) TestFunc4()  {}
+func (s *Suite009) TestFunc5()  {}
+func (s *Suite009) TestFunc6()  {}
+func (s *Suite009) TestFunc7()  {}
+func (s *Suite009) TestFunc8()  {}
+func (s *Suite009) TestFunc9()  {}
+func (s *Suite009) TestFunc10() {}
+
+func TestSuite009(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite009))
+}

--- a/testcontainers_tmpfs/suite010_test.go
+++ b/testcontainers_tmpfs/suite010_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite010 struct {
+	SuiteBase
+}
+
+func (s *Suite010) TestFunc1()  {}
+func (s *Suite010) TestFunc2()  {}
+func (s *Suite010) TestFunc3()  {}
+func (s *Suite010) TestFunc4()  {}
+func (s *Suite010) TestFunc5()  {}
+func (s *Suite010) TestFunc6()  {}
+func (s *Suite010) TestFunc7()  {}
+func (s *Suite010) TestFunc8()  {}
+func (s *Suite010) TestFunc9()  {}
+func (s *Suite010) TestFunc10() {}
+
+func TestSuite010(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite010))
+}

--- a/testcontainers_tmpfs/suite011_test.go
+++ b/testcontainers_tmpfs/suite011_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite011 struct {
+	SuiteBase
+}
+
+func (s *Suite011) TestFunc1()  {}
+func (s *Suite011) TestFunc2()  {}
+func (s *Suite011) TestFunc3()  {}
+func (s *Suite011) TestFunc4()  {}
+func (s *Suite011) TestFunc5()  {}
+func (s *Suite011) TestFunc6()  {}
+func (s *Suite011) TestFunc7()  {}
+func (s *Suite011) TestFunc8()  {}
+func (s *Suite011) TestFunc9()  {}
+func (s *Suite011) TestFunc10() {}
+
+func TestSuite011(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite011))
+}

--- a/testcontainers_tmpfs/suite012_test.go
+++ b/testcontainers_tmpfs/suite012_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite012 struct {
+	SuiteBase
+}
+
+func (s *Suite012) TestFunc1()  {}
+func (s *Suite012) TestFunc2()  {}
+func (s *Suite012) TestFunc3()  {}
+func (s *Suite012) TestFunc4()  {}
+func (s *Suite012) TestFunc5()  {}
+func (s *Suite012) TestFunc6()  {}
+func (s *Suite012) TestFunc7()  {}
+func (s *Suite012) TestFunc8()  {}
+func (s *Suite012) TestFunc9()  {}
+func (s *Suite012) TestFunc10() {}
+
+func TestSuite012(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite012))
+}

--- a/testcontainers_tmpfs/suite013_test.go
+++ b/testcontainers_tmpfs/suite013_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite013 struct {
+	SuiteBase
+}
+
+func (s *Suite013) TestFunc1()  {}
+func (s *Suite013) TestFunc2()  {}
+func (s *Suite013) TestFunc3()  {}
+func (s *Suite013) TestFunc4()  {}
+func (s *Suite013) TestFunc5()  {}
+func (s *Suite013) TestFunc6()  {}
+func (s *Suite013) TestFunc7()  {}
+func (s *Suite013) TestFunc8()  {}
+func (s *Suite013) TestFunc9()  {}
+func (s *Suite013) TestFunc10() {}
+
+func TestSuite013(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite013))
+}

--- a/testcontainers_tmpfs/suite014_test.go
+++ b/testcontainers_tmpfs/suite014_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite014 struct {
+	SuiteBase
+}
+
+func (s *Suite014) TestFunc1()  {}
+func (s *Suite014) TestFunc2()  {}
+func (s *Suite014) TestFunc3()  {}
+func (s *Suite014) TestFunc4()  {}
+func (s *Suite014) TestFunc5()  {}
+func (s *Suite014) TestFunc6()  {}
+func (s *Suite014) TestFunc7()  {}
+func (s *Suite014) TestFunc8()  {}
+func (s *Suite014) TestFunc9()  {}
+func (s *Suite014) TestFunc10() {}
+
+func TestSuite014(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite014))
+}

--- a/testcontainers_tmpfs/suite015_test.go
+++ b/testcontainers_tmpfs/suite015_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite015 struct {
+	SuiteBase
+}
+
+func (s *Suite015) TestFunc1()  {}
+func (s *Suite015) TestFunc2()  {}
+func (s *Suite015) TestFunc3()  {}
+func (s *Suite015) TestFunc4()  {}
+func (s *Suite015) TestFunc5()  {}
+func (s *Suite015) TestFunc6()  {}
+func (s *Suite015) TestFunc7()  {}
+func (s *Suite015) TestFunc8()  {}
+func (s *Suite015) TestFunc9()  {}
+func (s *Suite015) TestFunc10() {}
+
+func TestSuite015(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite015))
+}

--- a/testcontainers_tmpfs/suite016_test.go
+++ b/testcontainers_tmpfs/suite016_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite016 struct {
+	SuiteBase
+}
+
+func (s *Suite016) TestFunc1()  {}
+func (s *Suite016) TestFunc2()  {}
+func (s *Suite016) TestFunc3()  {}
+func (s *Suite016) TestFunc4()  {}
+func (s *Suite016) TestFunc5()  {}
+func (s *Suite016) TestFunc6()  {}
+func (s *Suite016) TestFunc7()  {}
+func (s *Suite016) TestFunc8()  {}
+func (s *Suite016) TestFunc9()  {}
+func (s *Suite016) TestFunc10() {}
+
+func TestSuite016(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite016))
+}

--- a/testcontainers_tmpfs/suite017_test.go
+++ b/testcontainers_tmpfs/suite017_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite017 struct {
+	SuiteBase
+}
+
+func (s *Suite017) TestFunc1()  {}
+func (s *Suite017) TestFunc2()  {}
+func (s *Suite017) TestFunc3()  {}
+func (s *Suite017) TestFunc4()  {}
+func (s *Suite017) TestFunc5()  {}
+func (s *Suite017) TestFunc6()  {}
+func (s *Suite017) TestFunc7()  {}
+func (s *Suite017) TestFunc8()  {}
+func (s *Suite017) TestFunc9()  {}
+func (s *Suite017) TestFunc10() {}
+
+func TestSuite017(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite017))
+}

--- a/testcontainers_tmpfs/suite018_test.go
+++ b/testcontainers_tmpfs/suite018_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite018 struct {
+	SuiteBase
+}
+
+func (s *Suite018) TestFunc1()  {}
+func (s *Suite018) TestFunc2()  {}
+func (s *Suite018) TestFunc3()  {}
+func (s *Suite018) TestFunc4()  {}
+func (s *Suite018) TestFunc5()  {}
+func (s *Suite018) TestFunc6()  {}
+func (s *Suite018) TestFunc7()  {}
+func (s *Suite018) TestFunc8()  {}
+func (s *Suite018) TestFunc9()  {}
+func (s *Suite018) TestFunc10() {}
+
+func TestSuite018(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite018))
+}

--- a/testcontainers_tmpfs/suite019_test.go
+++ b/testcontainers_tmpfs/suite019_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite019 struct {
+	SuiteBase
+}
+
+func (s *Suite019) TestFunc1()  {}
+func (s *Suite019) TestFunc2()  {}
+func (s *Suite019) TestFunc3()  {}
+func (s *Suite019) TestFunc4()  {}
+func (s *Suite019) TestFunc5()  {}
+func (s *Suite019) TestFunc6()  {}
+func (s *Suite019) TestFunc7()  {}
+func (s *Suite019) TestFunc8()  {}
+func (s *Suite019) TestFunc9()  {}
+func (s *Suite019) TestFunc10() {}
+
+func TestSuite019(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite019))
+}

--- a/testcontainers_tmpfs/suite020_test.go
+++ b/testcontainers_tmpfs/suite020_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite020 struct {
+	SuiteBase
+}
+
+func (s *Suite020) TestFunc1()  {}
+func (s *Suite020) TestFunc2()  {}
+func (s *Suite020) TestFunc3()  {}
+func (s *Suite020) TestFunc4()  {}
+func (s *Suite020) TestFunc5()  {}
+func (s *Suite020) TestFunc6()  {}
+func (s *Suite020) TestFunc7()  {}
+func (s *Suite020) TestFunc8()  {}
+func (s *Suite020) TestFunc9()  {}
+func (s *Suite020) TestFunc10() {}
+
+func TestSuite020(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite020))
+}

--- a/testcontainers_tmpfs/suite021_test.go
+++ b/testcontainers_tmpfs/suite021_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite021 struct {
+	SuiteBase
+}
+
+func (s *Suite021) TestFunc1()  {}
+func (s *Suite021) TestFunc2()  {}
+func (s *Suite021) TestFunc3()  {}
+func (s *Suite021) TestFunc4()  {}
+func (s *Suite021) TestFunc5()  {}
+func (s *Suite021) TestFunc6()  {}
+func (s *Suite021) TestFunc7()  {}
+func (s *Suite021) TestFunc8()  {}
+func (s *Suite021) TestFunc9()  {}
+func (s *Suite021) TestFunc10() {}
+
+func TestSuite021(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite021))
+}

--- a/testcontainers_tmpfs/suite022_test.go
+++ b/testcontainers_tmpfs/suite022_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite022 struct {
+	SuiteBase
+}
+
+func (s *Suite022) TestFunc1()  {}
+func (s *Suite022) TestFunc2()  {}
+func (s *Suite022) TestFunc3()  {}
+func (s *Suite022) TestFunc4()  {}
+func (s *Suite022) TestFunc5()  {}
+func (s *Suite022) TestFunc6()  {}
+func (s *Suite022) TestFunc7()  {}
+func (s *Suite022) TestFunc8()  {}
+func (s *Suite022) TestFunc9()  {}
+func (s *Suite022) TestFunc10() {}
+
+func TestSuite022(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite022))
+}

--- a/testcontainers_tmpfs/suite023_test.go
+++ b/testcontainers_tmpfs/suite023_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite023 struct {
+	SuiteBase
+}
+
+func (s *Suite023) TestFunc1()  {}
+func (s *Suite023) TestFunc2()  {}
+func (s *Suite023) TestFunc3()  {}
+func (s *Suite023) TestFunc4()  {}
+func (s *Suite023) TestFunc5()  {}
+func (s *Suite023) TestFunc6()  {}
+func (s *Suite023) TestFunc7()  {}
+func (s *Suite023) TestFunc8()  {}
+func (s *Suite023) TestFunc9()  {}
+func (s *Suite023) TestFunc10() {}
+
+func TestSuite023(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite023))
+}

--- a/testcontainers_tmpfs/suite024_test.go
+++ b/testcontainers_tmpfs/suite024_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite024 struct {
+	SuiteBase
+}
+
+func (s *Suite024) TestFunc1()  {}
+func (s *Suite024) TestFunc2()  {}
+func (s *Suite024) TestFunc3()  {}
+func (s *Suite024) TestFunc4()  {}
+func (s *Suite024) TestFunc5()  {}
+func (s *Suite024) TestFunc6()  {}
+func (s *Suite024) TestFunc7()  {}
+func (s *Suite024) TestFunc8()  {}
+func (s *Suite024) TestFunc9()  {}
+func (s *Suite024) TestFunc10() {}
+
+func TestSuite024(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite024))
+}

--- a/testcontainers_tmpfs/suite025_test.go
+++ b/testcontainers_tmpfs/suite025_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite025 struct {
+	SuiteBase
+}
+
+func (s *Suite025) TestFunc1()  {}
+func (s *Suite025) TestFunc2()  {}
+func (s *Suite025) TestFunc3()  {}
+func (s *Suite025) TestFunc4()  {}
+func (s *Suite025) TestFunc5()  {}
+func (s *Suite025) TestFunc6()  {}
+func (s *Suite025) TestFunc7()  {}
+func (s *Suite025) TestFunc8()  {}
+func (s *Suite025) TestFunc9()  {}
+func (s *Suite025) TestFunc10() {}
+
+func TestSuite025(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite025))
+}

--- a/testcontainers_tmpfs/suite026_test.go
+++ b/testcontainers_tmpfs/suite026_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite026 struct {
+	SuiteBase
+}
+
+func (s *Suite026) TestFunc1()  {}
+func (s *Suite026) TestFunc2()  {}
+func (s *Suite026) TestFunc3()  {}
+func (s *Suite026) TestFunc4()  {}
+func (s *Suite026) TestFunc5()  {}
+func (s *Suite026) TestFunc6()  {}
+func (s *Suite026) TestFunc7()  {}
+func (s *Suite026) TestFunc8()  {}
+func (s *Suite026) TestFunc9()  {}
+func (s *Suite026) TestFunc10() {}
+
+func TestSuite026(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite026))
+}

--- a/testcontainers_tmpfs/suite027_test.go
+++ b/testcontainers_tmpfs/suite027_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite027 struct {
+	SuiteBase
+}
+
+func (s *Suite027) TestFunc1()  {}
+func (s *Suite027) TestFunc2()  {}
+func (s *Suite027) TestFunc3()  {}
+func (s *Suite027) TestFunc4()  {}
+func (s *Suite027) TestFunc5()  {}
+func (s *Suite027) TestFunc6()  {}
+func (s *Suite027) TestFunc7()  {}
+func (s *Suite027) TestFunc8()  {}
+func (s *Suite027) TestFunc9()  {}
+func (s *Suite027) TestFunc10() {}
+
+func TestSuite027(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite027))
+}

--- a/testcontainers_tmpfs/suite028_test.go
+++ b/testcontainers_tmpfs/suite028_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite028 struct {
+	SuiteBase
+}
+
+func (s *Suite028) TestFunc1()  {}
+func (s *Suite028) TestFunc2()  {}
+func (s *Suite028) TestFunc3()  {}
+func (s *Suite028) TestFunc4()  {}
+func (s *Suite028) TestFunc5()  {}
+func (s *Suite028) TestFunc6()  {}
+func (s *Suite028) TestFunc7()  {}
+func (s *Suite028) TestFunc8()  {}
+func (s *Suite028) TestFunc9()  {}
+func (s *Suite028) TestFunc10() {}
+
+func TestSuite028(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite028))
+}

--- a/testcontainers_tmpfs/suite029_test.go
+++ b/testcontainers_tmpfs/suite029_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite029 struct {
+	SuiteBase
+}
+
+func (s *Suite029) TestFunc1()  {}
+func (s *Suite029) TestFunc2()  {}
+func (s *Suite029) TestFunc3()  {}
+func (s *Suite029) TestFunc4()  {}
+func (s *Suite029) TestFunc5()  {}
+func (s *Suite029) TestFunc6()  {}
+func (s *Suite029) TestFunc7()  {}
+func (s *Suite029) TestFunc8()  {}
+func (s *Suite029) TestFunc9()  {}
+func (s *Suite029) TestFunc10() {}
+
+func TestSuite029(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite029))
+}

--- a/testcontainers_tmpfs/suite030_test.go
+++ b/testcontainers_tmpfs/suite030_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite030 struct {
+	SuiteBase
+}
+
+func (s *Suite030) TestFunc1()  {}
+func (s *Suite030) TestFunc2()  {}
+func (s *Suite030) TestFunc3()  {}
+func (s *Suite030) TestFunc4()  {}
+func (s *Suite030) TestFunc5()  {}
+func (s *Suite030) TestFunc6()  {}
+func (s *Suite030) TestFunc7()  {}
+func (s *Suite030) TestFunc8()  {}
+func (s *Suite030) TestFunc9()  {}
+func (s *Suite030) TestFunc10() {}
+
+func TestSuite030(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite030))
+}

--- a/testcontainers_tmpfs/suite031_test.go
+++ b/testcontainers_tmpfs/suite031_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite031 struct {
+	SuiteBase
+}
+
+func (s *Suite031) TestFunc1()  {}
+func (s *Suite031) TestFunc2()  {}
+func (s *Suite031) TestFunc3()  {}
+func (s *Suite031) TestFunc4()  {}
+func (s *Suite031) TestFunc5()  {}
+func (s *Suite031) TestFunc6()  {}
+func (s *Suite031) TestFunc7()  {}
+func (s *Suite031) TestFunc8()  {}
+func (s *Suite031) TestFunc9()  {}
+func (s *Suite031) TestFunc10() {}
+
+func TestSuite031(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite031))
+}

--- a/testcontainers_tmpfs/suite032_test.go
+++ b/testcontainers_tmpfs/suite032_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite032 struct {
+	SuiteBase
+}
+
+func (s *Suite032) TestFunc1()  {}
+func (s *Suite032) TestFunc2()  {}
+func (s *Suite032) TestFunc3()  {}
+func (s *Suite032) TestFunc4()  {}
+func (s *Suite032) TestFunc5()  {}
+func (s *Suite032) TestFunc6()  {}
+func (s *Suite032) TestFunc7()  {}
+func (s *Suite032) TestFunc8()  {}
+func (s *Suite032) TestFunc9()  {}
+func (s *Suite032) TestFunc10() {}
+
+func TestSuite032(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite032))
+}

--- a/testcontainers_tmpfs/suite033_test.go
+++ b/testcontainers_tmpfs/suite033_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite033 struct {
+	SuiteBase
+}
+
+func (s *Suite033) TestFunc1()  {}
+func (s *Suite033) TestFunc2()  {}
+func (s *Suite033) TestFunc3()  {}
+func (s *Suite033) TestFunc4()  {}
+func (s *Suite033) TestFunc5()  {}
+func (s *Suite033) TestFunc6()  {}
+func (s *Suite033) TestFunc7()  {}
+func (s *Suite033) TestFunc8()  {}
+func (s *Suite033) TestFunc9()  {}
+func (s *Suite033) TestFunc10() {}
+
+func TestSuite033(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite033))
+}

--- a/testcontainers_tmpfs/suite034_test.go
+++ b/testcontainers_tmpfs/suite034_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite034 struct {
+	SuiteBase
+}
+
+func (s *Suite034) TestFunc1()  {}
+func (s *Suite034) TestFunc2()  {}
+func (s *Suite034) TestFunc3()  {}
+func (s *Suite034) TestFunc4()  {}
+func (s *Suite034) TestFunc5()  {}
+func (s *Suite034) TestFunc6()  {}
+func (s *Suite034) TestFunc7()  {}
+func (s *Suite034) TestFunc8()  {}
+func (s *Suite034) TestFunc9()  {}
+func (s *Suite034) TestFunc10() {}
+
+func TestSuite034(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite034))
+}

--- a/testcontainers_tmpfs/suite035_test.go
+++ b/testcontainers_tmpfs/suite035_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite035 struct {
+	SuiteBase
+}
+
+func (s *Suite035) TestFunc1()  {}
+func (s *Suite035) TestFunc2()  {}
+func (s *Suite035) TestFunc3()  {}
+func (s *Suite035) TestFunc4()  {}
+func (s *Suite035) TestFunc5()  {}
+func (s *Suite035) TestFunc6()  {}
+func (s *Suite035) TestFunc7()  {}
+func (s *Suite035) TestFunc8()  {}
+func (s *Suite035) TestFunc9()  {}
+func (s *Suite035) TestFunc10() {}
+
+func TestSuite035(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite035))
+}

--- a/testcontainers_tmpfs/suite036_test.go
+++ b/testcontainers_tmpfs/suite036_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite036 struct {
+	SuiteBase
+}
+
+func (s *Suite036) TestFunc1()  {}
+func (s *Suite036) TestFunc2()  {}
+func (s *Suite036) TestFunc3()  {}
+func (s *Suite036) TestFunc4()  {}
+func (s *Suite036) TestFunc5()  {}
+func (s *Suite036) TestFunc6()  {}
+func (s *Suite036) TestFunc7()  {}
+func (s *Suite036) TestFunc8()  {}
+func (s *Suite036) TestFunc9()  {}
+func (s *Suite036) TestFunc10() {}
+
+func TestSuite036(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite036))
+}

--- a/testcontainers_tmpfs/suite037_test.go
+++ b/testcontainers_tmpfs/suite037_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite037 struct {
+	SuiteBase
+}
+
+func (s *Suite037) TestFunc1()  {}
+func (s *Suite037) TestFunc2()  {}
+func (s *Suite037) TestFunc3()  {}
+func (s *Suite037) TestFunc4()  {}
+func (s *Suite037) TestFunc5()  {}
+func (s *Suite037) TestFunc6()  {}
+func (s *Suite037) TestFunc7()  {}
+func (s *Suite037) TestFunc8()  {}
+func (s *Suite037) TestFunc9()  {}
+func (s *Suite037) TestFunc10() {}
+
+func TestSuite037(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite037))
+}

--- a/testcontainers_tmpfs/suite038_test.go
+++ b/testcontainers_tmpfs/suite038_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite038 struct {
+	SuiteBase
+}
+
+func (s *Suite038) TestFunc1()  {}
+func (s *Suite038) TestFunc2()  {}
+func (s *Suite038) TestFunc3()  {}
+func (s *Suite038) TestFunc4()  {}
+func (s *Suite038) TestFunc5()  {}
+func (s *Suite038) TestFunc6()  {}
+func (s *Suite038) TestFunc7()  {}
+func (s *Suite038) TestFunc8()  {}
+func (s *Suite038) TestFunc9()  {}
+func (s *Suite038) TestFunc10() {}
+
+func TestSuite038(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite038))
+}

--- a/testcontainers_tmpfs/suite039_test.go
+++ b/testcontainers_tmpfs/suite039_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite039 struct {
+	SuiteBase
+}
+
+func (s *Suite039) TestFunc1()  {}
+func (s *Suite039) TestFunc2()  {}
+func (s *Suite039) TestFunc3()  {}
+func (s *Suite039) TestFunc4()  {}
+func (s *Suite039) TestFunc5()  {}
+func (s *Suite039) TestFunc6()  {}
+func (s *Suite039) TestFunc7()  {}
+func (s *Suite039) TestFunc8()  {}
+func (s *Suite039) TestFunc9()  {}
+func (s *Suite039) TestFunc10() {}
+
+func TestSuite039(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite039))
+}

--- a/testcontainers_tmpfs/suite040_test.go
+++ b/testcontainers_tmpfs/suite040_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite040 struct {
+	SuiteBase
+}
+
+func (s *Suite040) TestFunc1()  {}
+func (s *Suite040) TestFunc2()  {}
+func (s *Suite040) TestFunc3()  {}
+func (s *Suite040) TestFunc4()  {}
+func (s *Suite040) TestFunc5()  {}
+func (s *Suite040) TestFunc6()  {}
+func (s *Suite040) TestFunc7()  {}
+func (s *Suite040) TestFunc8()  {}
+func (s *Suite040) TestFunc9()  {}
+func (s *Suite040) TestFunc10() {}
+
+func TestSuite040(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite040))
+}

--- a/testcontainers_tmpfs/suite041_test.go
+++ b/testcontainers_tmpfs/suite041_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite041 struct {
+	SuiteBase
+}
+
+func (s *Suite041) TestFunc1()  {}
+func (s *Suite041) TestFunc2()  {}
+func (s *Suite041) TestFunc3()  {}
+func (s *Suite041) TestFunc4()  {}
+func (s *Suite041) TestFunc5()  {}
+func (s *Suite041) TestFunc6()  {}
+func (s *Suite041) TestFunc7()  {}
+func (s *Suite041) TestFunc8()  {}
+func (s *Suite041) TestFunc9()  {}
+func (s *Suite041) TestFunc10() {}
+
+func TestSuite041(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite041))
+}

--- a/testcontainers_tmpfs/suite042_test.go
+++ b/testcontainers_tmpfs/suite042_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite042 struct {
+	SuiteBase
+}
+
+func (s *Suite042) TestFunc1()  {}
+func (s *Suite042) TestFunc2()  {}
+func (s *Suite042) TestFunc3()  {}
+func (s *Suite042) TestFunc4()  {}
+func (s *Suite042) TestFunc5()  {}
+func (s *Suite042) TestFunc6()  {}
+func (s *Suite042) TestFunc7()  {}
+func (s *Suite042) TestFunc8()  {}
+func (s *Suite042) TestFunc9()  {}
+func (s *Suite042) TestFunc10() {}
+
+func TestSuite042(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite042))
+}

--- a/testcontainers_tmpfs/suite043_test.go
+++ b/testcontainers_tmpfs/suite043_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite043 struct {
+	SuiteBase
+}
+
+func (s *Suite043) TestFunc1()  {}
+func (s *Suite043) TestFunc2()  {}
+func (s *Suite043) TestFunc3()  {}
+func (s *Suite043) TestFunc4()  {}
+func (s *Suite043) TestFunc5()  {}
+func (s *Suite043) TestFunc6()  {}
+func (s *Suite043) TestFunc7()  {}
+func (s *Suite043) TestFunc8()  {}
+func (s *Suite043) TestFunc9()  {}
+func (s *Suite043) TestFunc10() {}
+
+func TestSuite043(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite043))
+}

--- a/testcontainers_tmpfs/suite044_test.go
+++ b/testcontainers_tmpfs/suite044_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite044 struct {
+	SuiteBase
+}
+
+func (s *Suite044) TestFunc1()  {}
+func (s *Suite044) TestFunc2()  {}
+func (s *Suite044) TestFunc3()  {}
+func (s *Suite044) TestFunc4()  {}
+func (s *Suite044) TestFunc5()  {}
+func (s *Suite044) TestFunc6()  {}
+func (s *Suite044) TestFunc7()  {}
+func (s *Suite044) TestFunc8()  {}
+func (s *Suite044) TestFunc9()  {}
+func (s *Suite044) TestFunc10() {}
+
+func TestSuite044(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite044))
+}

--- a/testcontainers_tmpfs/suite045_test.go
+++ b/testcontainers_tmpfs/suite045_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite045 struct {
+	SuiteBase
+}
+
+func (s *Suite045) TestFunc1()  {}
+func (s *Suite045) TestFunc2()  {}
+func (s *Suite045) TestFunc3()  {}
+func (s *Suite045) TestFunc4()  {}
+func (s *Suite045) TestFunc5()  {}
+func (s *Suite045) TestFunc6()  {}
+func (s *Suite045) TestFunc7()  {}
+func (s *Suite045) TestFunc8()  {}
+func (s *Suite045) TestFunc9()  {}
+func (s *Suite045) TestFunc10() {}
+
+func TestSuite045(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite045))
+}

--- a/testcontainers_tmpfs/suite046_test.go
+++ b/testcontainers_tmpfs/suite046_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite046 struct {
+	SuiteBase
+}
+
+func (s *Suite046) TestFunc1()  {}
+func (s *Suite046) TestFunc2()  {}
+func (s *Suite046) TestFunc3()  {}
+func (s *Suite046) TestFunc4()  {}
+func (s *Suite046) TestFunc5()  {}
+func (s *Suite046) TestFunc6()  {}
+func (s *Suite046) TestFunc7()  {}
+func (s *Suite046) TestFunc8()  {}
+func (s *Suite046) TestFunc9()  {}
+func (s *Suite046) TestFunc10() {}
+
+func TestSuite046(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite046))
+}

--- a/testcontainers_tmpfs/suite047_test.go
+++ b/testcontainers_tmpfs/suite047_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite047 struct {
+	SuiteBase
+}
+
+func (s *Suite047) TestFunc1()  {}
+func (s *Suite047) TestFunc2()  {}
+func (s *Suite047) TestFunc3()  {}
+func (s *Suite047) TestFunc4()  {}
+func (s *Suite047) TestFunc5()  {}
+func (s *Suite047) TestFunc6()  {}
+func (s *Suite047) TestFunc7()  {}
+func (s *Suite047) TestFunc8()  {}
+func (s *Suite047) TestFunc9()  {}
+func (s *Suite047) TestFunc10() {}
+
+func TestSuite047(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite047))
+}

--- a/testcontainers_tmpfs/suite048_test.go
+++ b/testcontainers_tmpfs/suite048_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite048 struct {
+	SuiteBase
+}
+
+func (s *Suite048) TestFunc1()  {}
+func (s *Suite048) TestFunc2()  {}
+func (s *Suite048) TestFunc3()  {}
+func (s *Suite048) TestFunc4()  {}
+func (s *Suite048) TestFunc5()  {}
+func (s *Suite048) TestFunc6()  {}
+func (s *Suite048) TestFunc7()  {}
+func (s *Suite048) TestFunc8()  {}
+func (s *Suite048) TestFunc9()  {}
+func (s *Suite048) TestFunc10() {}
+
+func TestSuite048(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite048))
+}

--- a/testcontainers_tmpfs/suite049_test.go
+++ b/testcontainers_tmpfs/suite049_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite049 struct {
+	SuiteBase
+}
+
+func (s *Suite049) TestFunc1()  {}
+func (s *Suite049) TestFunc2()  {}
+func (s *Suite049) TestFunc3()  {}
+func (s *Suite049) TestFunc4()  {}
+func (s *Suite049) TestFunc5()  {}
+func (s *Suite049) TestFunc6()  {}
+func (s *Suite049) TestFunc7()  {}
+func (s *Suite049) TestFunc8()  {}
+func (s *Suite049) TestFunc9()  {}
+func (s *Suite049) TestFunc10() {}
+
+func TestSuite049(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite049))
+}

--- a/testcontainers_tmpfs/suite050_test.go
+++ b/testcontainers_tmpfs/suite050_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite050 struct {
+	SuiteBase
+}
+
+func (s *Suite050) TestFunc1()  {}
+func (s *Suite050) TestFunc2()  {}
+func (s *Suite050) TestFunc3()  {}
+func (s *Suite050) TestFunc4()  {}
+func (s *Suite050) TestFunc5()  {}
+func (s *Suite050) TestFunc6()  {}
+func (s *Suite050) TestFunc7()  {}
+func (s *Suite050) TestFunc8()  {}
+func (s *Suite050) TestFunc9()  {}
+func (s *Suite050) TestFunc10() {}
+
+func TestSuite050(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite050))
+}

--- a/testcontainers_tmpfs/suite051_test.go
+++ b/testcontainers_tmpfs/suite051_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite051 struct {
+	SuiteBase
+}
+
+func (s *Suite051) TestFunc1()  {}
+func (s *Suite051) TestFunc2()  {}
+func (s *Suite051) TestFunc3()  {}
+func (s *Suite051) TestFunc4()  {}
+func (s *Suite051) TestFunc5()  {}
+func (s *Suite051) TestFunc6()  {}
+func (s *Suite051) TestFunc7()  {}
+func (s *Suite051) TestFunc8()  {}
+func (s *Suite051) TestFunc9()  {}
+func (s *Suite051) TestFunc10() {}
+
+func TestSuite051(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite051))
+}

--- a/testcontainers_tmpfs/suite052_test.go
+++ b/testcontainers_tmpfs/suite052_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite052 struct {
+	SuiteBase
+}
+
+func (s *Suite052) TestFunc1()  {}
+func (s *Suite052) TestFunc2()  {}
+func (s *Suite052) TestFunc3()  {}
+func (s *Suite052) TestFunc4()  {}
+func (s *Suite052) TestFunc5()  {}
+func (s *Suite052) TestFunc6()  {}
+func (s *Suite052) TestFunc7()  {}
+func (s *Suite052) TestFunc8()  {}
+func (s *Suite052) TestFunc9()  {}
+func (s *Suite052) TestFunc10() {}
+
+func TestSuite052(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite052))
+}

--- a/testcontainers_tmpfs/suite053_test.go
+++ b/testcontainers_tmpfs/suite053_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite053 struct {
+	SuiteBase
+}
+
+func (s *Suite053) TestFunc1()  {}
+func (s *Suite053) TestFunc2()  {}
+func (s *Suite053) TestFunc3()  {}
+func (s *Suite053) TestFunc4()  {}
+func (s *Suite053) TestFunc5()  {}
+func (s *Suite053) TestFunc6()  {}
+func (s *Suite053) TestFunc7()  {}
+func (s *Suite053) TestFunc8()  {}
+func (s *Suite053) TestFunc9()  {}
+func (s *Suite053) TestFunc10() {}
+
+func TestSuite053(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite053))
+}

--- a/testcontainers_tmpfs/suite054_test.go
+++ b/testcontainers_tmpfs/suite054_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite054 struct {
+	SuiteBase
+}
+
+func (s *Suite054) TestFunc1()  {}
+func (s *Suite054) TestFunc2()  {}
+func (s *Suite054) TestFunc3()  {}
+func (s *Suite054) TestFunc4()  {}
+func (s *Suite054) TestFunc5()  {}
+func (s *Suite054) TestFunc6()  {}
+func (s *Suite054) TestFunc7()  {}
+func (s *Suite054) TestFunc8()  {}
+func (s *Suite054) TestFunc9()  {}
+func (s *Suite054) TestFunc10() {}
+
+func TestSuite054(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite054))
+}

--- a/testcontainers_tmpfs/suite055_test.go
+++ b/testcontainers_tmpfs/suite055_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite055 struct {
+	SuiteBase
+}
+
+func (s *Suite055) TestFunc1()  {}
+func (s *Suite055) TestFunc2()  {}
+func (s *Suite055) TestFunc3()  {}
+func (s *Suite055) TestFunc4()  {}
+func (s *Suite055) TestFunc5()  {}
+func (s *Suite055) TestFunc6()  {}
+func (s *Suite055) TestFunc7()  {}
+func (s *Suite055) TestFunc8()  {}
+func (s *Suite055) TestFunc9()  {}
+func (s *Suite055) TestFunc10() {}
+
+func TestSuite055(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite055))
+}

--- a/testcontainers_tmpfs/suite056_test.go
+++ b/testcontainers_tmpfs/suite056_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite056 struct {
+	SuiteBase
+}
+
+func (s *Suite056) TestFunc1()  {}
+func (s *Suite056) TestFunc2()  {}
+func (s *Suite056) TestFunc3()  {}
+func (s *Suite056) TestFunc4()  {}
+func (s *Suite056) TestFunc5()  {}
+func (s *Suite056) TestFunc6()  {}
+func (s *Suite056) TestFunc7()  {}
+func (s *Suite056) TestFunc8()  {}
+func (s *Suite056) TestFunc9()  {}
+func (s *Suite056) TestFunc10() {}
+
+func TestSuite056(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite056))
+}

--- a/testcontainers_tmpfs/suite057_test.go
+++ b/testcontainers_tmpfs/suite057_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite057 struct {
+	SuiteBase
+}
+
+func (s *Suite057) TestFunc1()  {}
+func (s *Suite057) TestFunc2()  {}
+func (s *Suite057) TestFunc3()  {}
+func (s *Suite057) TestFunc4()  {}
+func (s *Suite057) TestFunc5()  {}
+func (s *Suite057) TestFunc6()  {}
+func (s *Suite057) TestFunc7()  {}
+func (s *Suite057) TestFunc8()  {}
+func (s *Suite057) TestFunc9()  {}
+func (s *Suite057) TestFunc10() {}
+
+func TestSuite057(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite057))
+}

--- a/testcontainers_tmpfs/suite058_test.go
+++ b/testcontainers_tmpfs/suite058_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite058 struct {
+	SuiteBase
+}
+
+func (s *Suite058) TestFunc1()  {}
+func (s *Suite058) TestFunc2()  {}
+func (s *Suite058) TestFunc3()  {}
+func (s *Suite058) TestFunc4()  {}
+func (s *Suite058) TestFunc5()  {}
+func (s *Suite058) TestFunc6()  {}
+func (s *Suite058) TestFunc7()  {}
+func (s *Suite058) TestFunc8()  {}
+func (s *Suite058) TestFunc9()  {}
+func (s *Suite058) TestFunc10() {}
+
+func TestSuite058(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite058))
+}

--- a/testcontainers_tmpfs/suite059_test.go
+++ b/testcontainers_tmpfs/suite059_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite059 struct {
+	SuiteBase
+}
+
+func (s *Suite059) TestFunc1()  {}
+func (s *Suite059) TestFunc2()  {}
+func (s *Suite059) TestFunc3()  {}
+func (s *Suite059) TestFunc4()  {}
+func (s *Suite059) TestFunc5()  {}
+func (s *Suite059) TestFunc6()  {}
+func (s *Suite059) TestFunc7()  {}
+func (s *Suite059) TestFunc8()  {}
+func (s *Suite059) TestFunc9()  {}
+func (s *Suite059) TestFunc10() {}
+
+func TestSuite059(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite059))
+}

--- a/testcontainers_tmpfs/suite060_test.go
+++ b/testcontainers_tmpfs/suite060_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite060 struct {
+	SuiteBase
+}
+
+func (s *Suite060) TestFunc1()  {}
+func (s *Suite060) TestFunc2()  {}
+func (s *Suite060) TestFunc3()  {}
+func (s *Suite060) TestFunc4()  {}
+func (s *Suite060) TestFunc5()  {}
+func (s *Suite060) TestFunc6()  {}
+func (s *Suite060) TestFunc7()  {}
+func (s *Suite060) TestFunc8()  {}
+func (s *Suite060) TestFunc9()  {}
+func (s *Suite060) TestFunc10() {}
+
+func TestSuite060(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite060))
+}

--- a/testcontainers_tmpfs/suite061_test.go
+++ b/testcontainers_tmpfs/suite061_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite061 struct {
+	SuiteBase
+}
+
+func (s *Suite061) TestFunc1()  {}
+func (s *Suite061) TestFunc2()  {}
+func (s *Suite061) TestFunc3()  {}
+func (s *Suite061) TestFunc4()  {}
+func (s *Suite061) TestFunc5()  {}
+func (s *Suite061) TestFunc6()  {}
+func (s *Suite061) TestFunc7()  {}
+func (s *Suite061) TestFunc8()  {}
+func (s *Suite061) TestFunc9()  {}
+func (s *Suite061) TestFunc10() {}
+
+func TestSuite061(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite061))
+}

--- a/testcontainers_tmpfs/suite062_test.go
+++ b/testcontainers_tmpfs/suite062_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite062 struct {
+	SuiteBase
+}
+
+func (s *Suite062) TestFunc1()  {}
+func (s *Suite062) TestFunc2()  {}
+func (s *Suite062) TestFunc3()  {}
+func (s *Suite062) TestFunc4()  {}
+func (s *Suite062) TestFunc5()  {}
+func (s *Suite062) TestFunc6()  {}
+func (s *Suite062) TestFunc7()  {}
+func (s *Suite062) TestFunc8()  {}
+func (s *Suite062) TestFunc9()  {}
+func (s *Suite062) TestFunc10() {}
+
+func TestSuite062(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite062))
+}

--- a/testcontainers_tmpfs/suite063_test.go
+++ b/testcontainers_tmpfs/suite063_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite063 struct {
+	SuiteBase
+}
+
+func (s *Suite063) TestFunc1()  {}
+func (s *Suite063) TestFunc2()  {}
+func (s *Suite063) TestFunc3()  {}
+func (s *Suite063) TestFunc4()  {}
+func (s *Suite063) TestFunc5()  {}
+func (s *Suite063) TestFunc6()  {}
+func (s *Suite063) TestFunc7()  {}
+func (s *Suite063) TestFunc8()  {}
+func (s *Suite063) TestFunc9()  {}
+func (s *Suite063) TestFunc10() {}
+
+func TestSuite063(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite063))
+}

--- a/testcontainers_tmpfs/suite064_test.go
+++ b/testcontainers_tmpfs/suite064_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite064 struct {
+	SuiteBase
+}
+
+func (s *Suite064) TestFunc1()  {}
+func (s *Suite064) TestFunc2()  {}
+func (s *Suite064) TestFunc3()  {}
+func (s *Suite064) TestFunc4()  {}
+func (s *Suite064) TestFunc5()  {}
+func (s *Suite064) TestFunc6()  {}
+func (s *Suite064) TestFunc7()  {}
+func (s *Suite064) TestFunc8()  {}
+func (s *Suite064) TestFunc9()  {}
+func (s *Suite064) TestFunc10() {}
+
+func TestSuite064(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite064))
+}

--- a/testcontainers_tmpfs/suite065_test.go
+++ b/testcontainers_tmpfs/suite065_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite065 struct {
+	SuiteBase
+}
+
+func (s *Suite065) TestFunc1()  {}
+func (s *Suite065) TestFunc2()  {}
+func (s *Suite065) TestFunc3()  {}
+func (s *Suite065) TestFunc4()  {}
+func (s *Suite065) TestFunc5()  {}
+func (s *Suite065) TestFunc6()  {}
+func (s *Suite065) TestFunc7()  {}
+func (s *Suite065) TestFunc8()  {}
+func (s *Suite065) TestFunc9()  {}
+func (s *Suite065) TestFunc10() {}
+
+func TestSuite065(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite065))
+}

--- a/testcontainers_tmpfs/suite066_test.go
+++ b/testcontainers_tmpfs/suite066_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite066 struct {
+	SuiteBase
+}
+
+func (s *Suite066) TestFunc1()  {}
+func (s *Suite066) TestFunc2()  {}
+func (s *Suite066) TestFunc3()  {}
+func (s *Suite066) TestFunc4()  {}
+func (s *Suite066) TestFunc5()  {}
+func (s *Suite066) TestFunc6()  {}
+func (s *Suite066) TestFunc7()  {}
+func (s *Suite066) TestFunc8()  {}
+func (s *Suite066) TestFunc9()  {}
+func (s *Suite066) TestFunc10() {}
+
+func TestSuite066(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite066))
+}

--- a/testcontainers_tmpfs/suite067_test.go
+++ b/testcontainers_tmpfs/suite067_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite067 struct {
+	SuiteBase
+}
+
+func (s *Suite067) TestFunc1()  {}
+func (s *Suite067) TestFunc2()  {}
+func (s *Suite067) TestFunc3()  {}
+func (s *Suite067) TestFunc4()  {}
+func (s *Suite067) TestFunc5()  {}
+func (s *Suite067) TestFunc6()  {}
+func (s *Suite067) TestFunc7()  {}
+func (s *Suite067) TestFunc8()  {}
+func (s *Suite067) TestFunc9()  {}
+func (s *Suite067) TestFunc10() {}
+
+func TestSuite067(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite067))
+}

--- a/testcontainers_tmpfs/suite068_test.go
+++ b/testcontainers_tmpfs/suite068_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite068 struct {
+	SuiteBase
+}
+
+func (s *Suite068) TestFunc1()  {}
+func (s *Suite068) TestFunc2()  {}
+func (s *Suite068) TestFunc3()  {}
+func (s *Suite068) TestFunc4()  {}
+func (s *Suite068) TestFunc5()  {}
+func (s *Suite068) TestFunc6()  {}
+func (s *Suite068) TestFunc7()  {}
+func (s *Suite068) TestFunc8()  {}
+func (s *Suite068) TestFunc9()  {}
+func (s *Suite068) TestFunc10() {}
+
+func TestSuite068(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite068))
+}

--- a/testcontainers_tmpfs/suite069_test.go
+++ b/testcontainers_tmpfs/suite069_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite069 struct {
+	SuiteBase
+}
+
+func (s *Suite069) TestFunc1()  {}
+func (s *Suite069) TestFunc2()  {}
+func (s *Suite069) TestFunc3()  {}
+func (s *Suite069) TestFunc4()  {}
+func (s *Suite069) TestFunc5()  {}
+func (s *Suite069) TestFunc6()  {}
+func (s *Suite069) TestFunc7()  {}
+func (s *Suite069) TestFunc8()  {}
+func (s *Suite069) TestFunc9()  {}
+func (s *Suite069) TestFunc10() {}
+
+func TestSuite069(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite069))
+}

--- a/testcontainers_tmpfs/suite070_test.go
+++ b/testcontainers_tmpfs/suite070_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite070 struct {
+	SuiteBase
+}
+
+func (s *Suite070) TestFunc1()  {}
+func (s *Suite070) TestFunc2()  {}
+func (s *Suite070) TestFunc3()  {}
+func (s *Suite070) TestFunc4()  {}
+func (s *Suite070) TestFunc5()  {}
+func (s *Suite070) TestFunc6()  {}
+func (s *Suite070) TestFunc7()  {}
+func (s *Suite070) TestFunc8()  {}
+func (s *Suite070) TestFunc9()  {}
+func (s *Suite070) TestFunc10() {}
+
+func TestSuite070(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite070))
+}

--- a/testcontainers_tmpfs/suite071_test.go
+++ b/testcontainers_tmpfs/suite071_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite071 struct {
+	SuiteBase
+}
+
+func (s *Suite071) TestFunc1()  {}
+func (s *Suite071) TestFunc2()  {}
+func (s *Suite071) TestFunc3()  {}
+func (s *Suite071) TestFunc4()  {}
+func (s *Suite071) TestFunc5()  {}
+func (s *Suite071) TestFunc6()  {}
+func (s *Suite071) TestFunc7()  {}
+func (s *Suite071) TestFunc8()  {}
+func (s *Suite071) TestFunc9()  {}
+func (s *Suite071) TestFunc10() {}
+
+func TestSuite071(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite071))
+}

--- a/testcontainers_tmpfs/suite072_test.go
+++ b/testcontainers_tmpfs/suite072_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite072 struct {
+	SuiteBase
+}
+
+func (s *Suite072) TestFunc1()  {}
+func (s *Suite072) TestFunc2()  {}
+func (s *Suite072) TestFunc3()  {}
+func (s *Suite072) TestFunc4()  {}
+func (s *Suite072) TestFunc5()  {}
+func (s *Suite072) TestFunc6()  {}
+func (s *Suite072) TestFunc7()  {}
+func (s *Suite072) TestFunc8()  {}
+func (s *Suite072) TestFunc9()  {}
+func (s *Suite072) TestFunc10() {}
+
+func TestSuite072(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite072))
+}

--- a/testcontainers_tmpfs/suite073_test.go
+++ b/testcontainers_tmpfs/suite073_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite073 struct {
+	SuiteBase
+}
+
+func (s *Suite073) TestFunc1()  {}
+func (s *Suite073) TestFunc2()  {}
+func (s *Suite073) TestFunc3()  {}
+func (s *Suite073) TestFunc4()  {}
+func (s *Suite073) TestFunc5()  {}
+func (s *Suite073) TestFunc6()  {}
+func (s *Suite073) TestFunc7()  {}
+func (s *Suite073) TestFunc8()  {}
+func (s *Suite073) TestFunc9()  {}
+func (s *Suite073) TestFunc10() {}
+
+func TestSuite073(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite073))
+}

--- a/testcontainers_tmpfs/suite074_test.go
+++ b/testcontainers_tmpfs/suite074_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite074 struct {
+	SuiteBase
+}
+
+func (s *Suite074) TestFunc1()  {}
+func (s *Suite074) TestFunc2()  {}
+func (s *Suite074) TestFunc3()  {}
+func (s *Suite074) TestFunc4()  {}
+func (s *Suite074) TestFunc5()  {}
+func (s *Suite074) TestFunc6()  {}
+func (s *Suite074) TestFunc7()  {}
+func (s *Suite074) TestFunc8()  {}
+func (s *Suite074) TestFunc9()  {}
+func (s *Suite074) TestFunc10() {}
+
+func TestSuite074(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite074))
+}

--- a/testcontainers_tmpfs/suite075_test.go
+++ b/testcontainers_tmpfs/suite075_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite075 struct {
+	SuiteBase
+}
+
+func (s *Suite075) TestFunc1()  {}
+func (s *Suite075) TestFunc2()  {}
+func (s *Suite075) TestFunc3()  {}
+func (s *Suite075) TestFunc4()  {}
+func (s *Suite075) TestFunc5()  {}
+func (s *Suite075) TestFunc6()  {}
+func (s *Suite075) TestFunc7()  {}
+func (s *Suite075) TestFunc8()  {}
+func (s *Suite075) TestFunc9()  {}
+func (s *Suite075) TestFunc10() {}
+
+func TestSuite075(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite075))
+}

--- a/testcontainers_tmpfs/suite076_test.go
+++ b/testcontainers_tmpfs/suite076_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite076 struct {
+	SuiteBase
+}
+
+func (s *Suite076) TestFunc1()  {}
+func (s *Suite076) TestFunc2()  {}
+func (s *Suite076) TestFunc3()  {}
+func (s *Suite076) TestFunc4()  {}
+func (s *Suite076) TestFunc5()  {}
+func (s *Suite076) TestFunc6()  {}
+func (s *Suite076) TestFunc7()  {}
+func (s *Suite076) TestFunc8()  {}
+func (s *Suite076) TestFunc9()  {}
+func (s *Suite076) TestFunc10() {}
+
+func TestSuite076(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite076))
+}

--- a/testcontainers_tmpfs/suite077_test.go
+++ b/testcontainers_tmpfs/suite077_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite077 struct {
+	SuiteBase
+}
+
+func (s *Suite077) TestFunc1()  {}
+func (s *Suite077) TestFunc2()  {}
+func (s *Suite077) TestFunc3()  {}
+func (s *Suite077) TestFunc4()  {}
+func (s *Suite077) TestFunc5()  {}
+func (s *Suite077) TestFunc6()  {}
+func (s *Suite077) TestFunc7()  {}
+func (s *Suite077) TestFunc8()  {}
+func (s *Suite077) TestFunc9()  {}
+func (s *Suite077) TestFunc10() {}
+
+func TestSuite077(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite077))
+}

--- a/testcontainers_tmpfs/suite078_test.go
+++ b/testcontainers_tmpfs/suite078_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite078 struct {
+	SuiteBase
+}
+
+func (s *Suite078) TestFunc1()  {}
+func (s *Suite078) TestFunc2()  {}
+func (s *Suite078) TestFunc3()  {}
+func (s *Suite078) TestFunc4()  {}
+func (s *Suite078) TestFunc5()  {}
+func (s *Suite078) TestFunc6()  {}
+func (s *Suite078) TestFunc7()  {}
+func (s *Suite078) TestFunc8()  {}
+func (s *Suite078) TestFunc9()  {}
+func (s *Suite078) TestFunc10() {}
+
+func TestSuite078(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite078))
+}

--- a/testcontainers_tmpfs/suite079_test.go
+++ b/testcontainers_tmpfs/suite079_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite079 struct {
+	SuiteBase
+}
+
+func (s *Suite079) TestFunc1()  {}
+func (s *Suite079) TestFunc2()  {}
+func (s *Suite079) TestFunc3()  {}
+func (s *Suite079) TestFunc4()  {}
+func (s *Suite079) TestFunc5()  {}
+func (s *Suite079) TestFunc6()  {}
+func (s *Suite079) TestFunc7()  {}
+func (s *Suite079) TestFunc8()  {}
+func (s *Suite079) TestFunc9()  {}
+func (s *Suite079) TestFunc10() {}
+
+func TestSuite079(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite079))
+}

--- a/testcontainers_tmpfs/suite080_test.go
+++ b/testcontainers_tmpfs/suite080_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite080 struct {
+	SuiteBase
+}
+
+func (s *Suite080) TestFunc1()  {}
+func (s *Suite080) TestFunc2()  {}
+func (s *Suite080) TestFunc3()  {}
+func (s *Suite080) TestFunc4()  {}
+func (s *Suite080) TestFunc5()  {}
+func (s *Suite080) TestFunc6()  {}
+func (s *Suite080) TestFunc7()  {}
+func (s *Suite080) TestFunc8()  {}
+func (s *Suite080) TestFunc9()  {}
+func (s *Suite080) TestFunc10() {}
+
+func TestSuite080(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite080))
+}

--- a/testcontainers_tmpfs/suite081_test.go
+++ b/testcontainers_tmpfs/suite081_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite081 struct {
+	SuiteBase
+}
+
+func (s *Suite081) TestFunc1()  {}
+func (s *Suite081) TestFunc2()  {}
+func (s *Suite081) TestFunc3()  {}
+func (s *Suite081) TestFunc4()  {}
+func (s *Suite081) TestFunc5()  {}
+func (s *Suite081) TestFunc6()  {}
+func (s *Suite081) TestFunc7()  {}
+func (s *Suite081) TestFunc8()  {}
+func (s *Suite081) TestFunc9()  {}
+func (s *Suite081) TestFunc10() {}
+
+func TestSuite081(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite081))
+}

--- a/testcontainers_tmpfs/suite082_test.go
+++ b/testcontainers_tmpfs/suite082_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite082 struct {
+	SuiteBase
+}
+
+func (s *Suite082) TestFunc1()  {}
+func (s *Suite082) TestFunc2()  {}
+func (s *Suite082) TestFunc3()  {}
+func (s *Suite082) TestFunc4()  {}
+func (s *Suite082) TestFunc5()  {}
+func (s *Suite082) TestFunc6()  {}
+func (s *Suite082) TestFunc7()  {}
+func (s *Suite082) TestFunc8()  {}
+func (s *Suite082) TestFunc9()  {}
+func (s *Suite082) TestFunc10() {}
+
+func TestSuite082(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite082))
+}

--- a/testcontainers_tmpfs/suite083_test.go
+++ b/testcontainers_tmpfs/suite083_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite083 struct {
+	SuiteBase
+}
+
+func (s *Suite083) TestFunc1()  {}
+func (s *Suite083) TestFunc2()  {}
+func (s *Suite083) TestFunc3()  {}
+func (s *Suite083) TestFunc4()  {}
+func (s *Suite083) TestFunc5()  {}
+func (s *Suite083) TestFunc6()  {}
+func (s *Suite083) TestFunc7()  {}
+func (s *Suite083) TestFunc8()  {}
+func (s *Suite083) TestFunc9()  {}
+func (s *Suite083) TestFunc10() {}
+
+func TestSuite083(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite083))
+}

--- a/testcontainers_tmpfs/suite084_test.go
+++ b/testcontainers_tmpfs/suite084_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite084 struct {
+	SuiteBase
+}
+
+func (s *Suite084) TestFunc1()  {}
+func (s *Suite084) TestFunc2()  {}
+func (s *Suite084) TestFunc3()  {}
+func (s *Suite084) TestFunc4()  {}
+func (s *Suite084) TestFunc5()  {}
+func (s *Suite084) TestFunc6()  {}
+func (s *Suite084) TestFunc7()  {}
+func (s *Suite084) TestFunc8()  {}
+func (s *Suite084) TestFunc9()  {}
+func (s *Suite084) TestFunc10() {}
+
+func TestSuite084(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite084))
+}

--- a/testcontainers_tmpfs/suite085_test.go
+++ b/testcontainers_tmpfs/suite085_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite085 struct {
+	SuiteBase
+}
+
+func (s *Suite085) TestFunc1()  {}
+func (s *Suite085) TestFunc2()  {}
+func (s *Suite085) TestFunc3()  {}
+func (s *Suite085) TestFunc4()  {}
+func (s *Suite085) TestFunc5()  {}
+func (s *Suite085) TestFunc6()  {}
+func (s *Suite085) TestFunc7()  {}
+func (s *Suite085) TestFunc8()  {}
+func (s *Suite085) TestFunc9()  {}
+func (s *Suite085) TestFunc10() {}
+
+func TestSuite085(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite085))
+}

--- a/testcontainers_tmpfs/suite086_test.go
+++ b/testcontainers_tmpfs/suite086_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite086 struct {
+	SuiteBase
+}
+
+func (s *Suite086) TestFunc1()  {}
+func (s *Suite086) TestFunc2()  {}
+func (s *Suite086) TestFunc3()  {}
+func (s *Suite086) TestFunc4()  {}
+func (s *Suite086) TestFunc5()  {}
+func (s *Suite086) TestFunc6()  {}
+func (s *Suite086) TestFunc7()  {}
+func (s *Suite086) TestFunc8()  {}
+func (s *Suite086) TestFunc9()  {}
+func (s *Suite086) TestFunc10() {}
+
+func TestSuite086(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite086))
+}

--- a/testcontainers_tmpfs/suite087_test.go
+++ b/testcontainers_tmpfs/suite087_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite087 struct {
+	SuiteBase
+}
+
+func (s *Suite087) TestFunc1()  {}
+func (s *Suite087) TestFunc2()  {}
+func (s *Suite087) TestFunc3()  {}
+func (s *Suite087) TestFunc4()  {}
+func (s *Suite087) TestFunc5()  {}
+func (s *Suite087) TestFunc6()  {}
+func (s *Suite087) TestFunc7()  {}
+func (s *Suite087) TestFunc8()  {}
+func (s *Suite087) TestFunc9()  {}
+func (s *Suite087) TestFunc10() {}
+
+func TestSuite087(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite087))
+}

--- a/testcontainers_tmpfs/suite088_test.go
+++ b/testcontainers_tmpfs/suite088_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite088 struct {
+	SuiteBase
+}
+
+func (s *Suite088) TestFunc1()  {}
+func (s *Suite088) TestFunc2()  {}
+func (s *Suite088) TestFunc3()  {}
+func (s *Suite088) TestFunc4()  {}
+func (s *Suite088) TestFunc5()  {}
+func (s *Suite088) TestFunc6()  {}
+func (s *Suite088) TestFunc7()  {}
+func (s *Suite088) TestFunc8()  {}
+func (s *Suite088) TestFunc9()  {}
+func (s *Suite088) TestFunc10() {}
+
+func TestSuite088(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite088))
+}

--- a/testcontainers_tmpfs/suite089_test.go
+++ b/testcontainers_tmpfs/suite089_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite089 struct {
+	SuiteBase
+}
+
+func (s *Suite089) TestFunc1()  {}
+func (s *Suite089) TestFunc2()  {}
+func (s *Suite089) TestFunc3()  {}
+func (s *Suite089) TestFunc4()  {}
+func (s *Suite089) TestFunc5()  {}
+func (s *Suite089) TestFunc6()  {}
+func (s *Suite089) TestFunc7()  {}
+func (s *Suite089) TestFunc8()  {}
+func (s *Suite089) TestFunc9()  {}
+func (s *Suite089) TestFunc10() {}
+
+func TestSuite089(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite089))
+}

--- a/testcontainers_tmpfs/suite090_test.go
+++ b/testcontainers_tmpfs/suite090_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite090 struct {
+	SuiteBase
+}
+
+func (s *Suite090) TestFunc1()  {}
+func (s *Suite090) TestFunc2()  {}
+func (s *Suite090) TestFunc3()  {}
+func (s *Suite090) TestFunc4()  {}
+func (s *Suite090) TestFunc5()  {}
+func (s *Suite090) TestFunc6()  {}
+func (s *Suite090) TestFunc7()  {}
+func (s *Suite090) TestFunc8()  {}
+func (s *Suite090) TestFunc9()  {}
+func (s *Suite090) TestFunc10() {}
+
+func TestSuite090(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite090))
+}

--- a/testcontainers_tmpfs/suite091_test.go
+++ b/testcontainers_tmpfs/suite091_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite091 struct {
+	SuiteBase
+}
+
+func (s *Suite091) TestFunc1()  {}
+func (s *Suite091) TestFunc2()  {}
+func (s *Suite091) TestFunc3()  {}
+func (s *Suite091) TestFunc4()  {}
+func (s *Suite091) TestFunc5()  {}
+func (s *Suite091) TestFunc6()  {}
+func (s *Suite091) TestFunc7()  {}
+func (s *Suite091) TestFunc8()  {}
+func (s *Suite091) TestFunc9()  {}
+func (s *Suite091) TestFunc10() {}
+
+func TestSuite091(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite091))
+}

--- a/testcontainers_tmpfs/suite092_test.go
+++ b/testcontainers_tmpfs/suite092_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite092 struct {
+	SuiteBase
+}
+
+func (s *Suite092) TestFunc1()  {}
+func (s *Suite092) TestFunc2()  {}
+func (s *Suite092) TestFunc3()  {}
+func (s *Suite092) TestFunc4()  {}
+func (s *Suite092) TestFunc5()  {}
+func (s *Suite092) TestFunc6()  {}
+func (s *Suite092) TestFunc7()  {}
+func (s *Suite092) TestFunc8()  {}
+func (s *Suite092) TestFunc9()  {}
+func (s *Suite092) TestFunc10() {}
+
+func TestSuite092(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite092))
+}

--- a/testcontainers_tmpfs/suite093_test.go
+++ b/testcontainers_tmpfs/suite093_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite093 struct {
+	SuiteBase
+}
+
+func (s *Suite093) TestFunc1()  {}
+func (s *Suite093) TestFunc2()  {}
+func (s *Suite093) TestFunc3()  {}
+func (s *Suite093) TestFunc4()  {}
+func (s *Suite093) TestFunc5()  {}
+func (s *Suite093) TestFunc6()  {}
+func (s *Suite093) TestFunc7()  {}
+func (s *Suite093) TestFunc8()  {}
+func (s *Suite093) TestFunc9()  {}
+func (s *Suite093) TestFunc10() {}
+
+func TestSuite093(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite093))
+}

--- a/testcontainers_tmpfs/suite094_test.go
+++ b/testcontainers_tmpfs/suite094_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite094 struct {
+	SuiteBase
+}
+
+func (s *Suite094) TestFunc1()  {}
+func (s *Suite094) TestFunc2()  {}
+func (s *Suite094) TestFunc3()  {}
+func (s *Suite094) TestFunc4()  {}
+func (s *Suite094) TestFunc5()  {}
+func (s *Suite094) TestFunc6()  {}
+func (s *Suite094) TestFunc7()  {}
+func (s *Suite094) TestFunc8()  {}
+func (s *Suite094) TestFunc9()  {}
+func (s *Suite094) TestFunc10() {}
+
+func TestSuite094(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite094))
+}

--- a/testcontainers_tmpfs/suite095_test.go
+++ b/testcontainers_tmpfs/suite095_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite095 struct {
+	SuiteBase
+}
+
+func (s *Suite095) TestFunc1()  {}
+func (s *Suite095) TestFunc2()  {}
+func (s *Suite095) TestFunc3()  {}
+func (s *Suite095) TestFunc4()  {}
+func (s *Suite095) TestFunc5()  {}
+func (s *Suite095) TestFunc6()  {}
+func (s *Suite095) TestFunc7()  {}
+func (s *Suite095) TestFunc8()  {}
+func (s *Suite095) TestFunc9()  {}
+func (s *Suite095) TestFunc10() {}
+
+func TestSuite095(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite095))
+}

--- a/testcontainers_tmpfs/suite096_test.go
+++ b/testcontainers_tmpfs/suite096_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite096 struct {
+	SuiteBase
+}
+
+func (s *Suite096) TestFunc1()  {}
+func (s *Suite096) TestFunc2()  {}
+func (s *Suite096) TestFunc3()  {}
+func (s *Suite096) TestFunc4()  {}
+func (s *Suite096) TestFunc5()  {}
+func (s *Suite096) TestFunc6()  {}
+func (s *Suite096) TestFunc7()  {}
+func (s *Suite096) TestFunc8()  {}
+func (s *Suite096) TestFunc9()  {}
+func (s *Suite096) TestFunc10() {}
+
+func TestSuite096(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite096))
+}

--- a/testcontainers_tmpfs/suite097_test.go
+++ b/testcontainers_tmpfs/suite097_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite097 struct {
+	SuiteBase
+}
+
+func (s *Suite097) TestFunc1()  {}
+func (s *Suite097) TestFunc2()  {}
+func (s *Suite097) TestFunc3()  {}
+func (s *Suite097) TestFunc4()  {}
+func (s *Suite097) TestFunc5()  {}
+func (s *Suite097) TestFunc6()  {}
+func (s *Suite097) TestFunc7()  {}
+func (s *Suite097) TestFunc8()  {}
+func (s *Suite097) TestFunc9()  {}
+func (s *Suite097) TestFunc10() {}
+
+func TestSuite097(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite097))
+}

--- a/testcontainers_tmpfs/suite098_test.go
+++ b/testcontainers_tmpfs/suite098_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite098 struct {
+	SuiteBase
+}
+
+func (s *Suite098) TestFunc1()  {}
+func (s *Suite098) TestFunc2()  {}
+func (s *Suite098) TestFunc3()  {}
+func (s *Suite098) TestFunc4()  {}
+func (s *Suite098) TestFunc5()  {}
+func (s *Suite098) TestFunc6()  {}
+func (s *Suite098) TestFunc7()  {}
+func (s *Suite098) TestFunc8()  {}
+func (s *Suite098) TestFunc9()  {}
+func (s *Suite098) TestFunc10() {}
+
+func TestSuite098(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite098))
+}

--- a/testcontainers_tmpfs/suite099_test.go
+++ b/testcontainers_tmpfs/suite099_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite099 struct {
+	SuiteBase
+}
+
+func (s *Suite099) TestFunc1()  {}
+func (s *Suite099) TestFunc2()  {}
+func (s *Suite099) TestFunc3()  {}
+func (s *Suite099) TestFunc4()  {}
+func (s *Suite099) TestFunc5()  {}
+func (s *Suite099) TestFunc6()  {}
+func (s *Suite099) TestFunc7()  {}
+func (s *Suite099) TestFunc8()  {}
+func (s *Suite099) TestFunc9()  {}
+func (s *Suite099) TestFunc10() {}
+
+func TestSuite099(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite099))
+}

--- a/testcontainers_tmpfs/suite100_test.go
+++ b/testcontainers_tmpfs/suite100_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite100 struct {
+	SuiteBase
+}
+
+func (s *Suite100) TestFunc1()  {}
+func (s *Suite100) TestFunc2()  {}
+func (s *Suite100) TestFunc3()  {}
+func (s *Suite100) TestFunc4()  {}
+func (s *Suite100) TestFunc5()  {}
+func (s *Suite100) TestFunc6()  {}
+func (s *Suite100) TestFunc7()  {}
+func (s *Suite100) TestFunc8()  {}
+func (s *Suite100) TestFunc9()  {}
+func (s *Suite100) TestFunc10() {}
+
+func TestSuite100(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite100))
+}

--- a/testcontainers_tmpfs/template_test.go
+++ b/testcontainers_tmpfs/template_test.go
@@ -1,0 +1,26 @@
+package testcontainers_tmpfs
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type Suite1 struct {
+	SuiteBase
+}
+
+func (s *Suite1) TestFunc1()  {}
+func (s *Suite1) TestFunc2()  {}
+func (s *Suite1) TestFunc3()  {}
+func (s *Suite1) TestFunc4()  {}
+func (s *Suite1) TestFunc5()  {}
+func (s *Suite1) TestFunc6()  {}
+func (s *Suite1) TestFunc7()  {}
+func (s *Suite1) TestFunc8()  {}
+func (s *Suite1) TestFunc9()  {}
+func (s *Suite1) TestFunc10() {}
+
+func TestSuite1(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(Suite1))
+}

--- a/testinfra/db.go
+++ b/testinfra/db.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/samber/lo"
 	"os"
+	"testing"
 )
 
 const ENV_NAME_DB_CONN_STR = "TEST_DB_CONN_STR"
@@ -19,16 +20,17 @@ type DB interface {
 	Close()
 }
 
-func MustStartDB() DB {
-	return lo.Must(StartDB())
+func MustStartDB(t *testing.T, useTmpfs bool) DB {
+	return lo.Must(StartDB(t, useTmpfs))
 }
 
-func StartDB() (DB, error) {
+func StartDB(t *testing.T, useTmpfs bool) (DB, error) {
+	t.TempDir()
 	connStr := os.Getenv(ENV_NAME_DB_CONN_STR)
 	if connStr != "" {
 		return newExternalDB(connStr)
 	}
-	return newContainerDB()
+	return newContainerDB(t, useTmpfs)
 }
 
 func applyMigrations(connCfg pgx.ConnConfig) error {

--- a/testinfra/db_container.go
+++ b/testinfra/db_container.go
@@ -3,12 +3,13 @@ package testinfra
 import (
 	"context"
 	"fmt"
-	"github.com/testcontainers/testcontainers-go"
-
+	"github.com/docker/docker/api/types/container"
 	"github.com/jackc/pgx/v5"
 	"github.com/samber/lo"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"testing"
 )
 
 var _ DB = (*containerDB)(nil)
@@ -18,23 +19,18 @@ type containerDB struct {
 	connStr string
 }
 
-func newContainerDB() (db *containerDB, err error) {
+func newContainerDB(t *testing.T, useTmpfs bool) (db *containerDB, err error) {
 	// run container
 
 	ctx := context.Background()
-	ctr, err := postgres.Run(ctx, "postgres:15",
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
-		postgres.WithDatabase("integration_tests_db"),
-		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
-			req.Cmd = append(req.Cmd, "-c", "log_statement=all")
-			return nil
-		}),
-	)
-	defer func() {
-		if err != nil {
-			_ = testcontainers.TerminateContainer(ctr)
-		}
-	}()
+
+	var ctr *postgres.PostgresContainer
+	if useTmpfs {
+		ctr, err = RunPostgresContainerWithTmpfs(ctx)
+	} else {
+		ctr, err = RunPostgresContainer(ctx)
+	}
+	testcontainers.CleanupContainer(t, ctr)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +57,44 @@ func newContainerDB() (db *containerDB, err error) {
 		ctr:     ctr,
 		connStr: connStr,
 	}, nil
+}
+
+func RunPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, error) {
+	return postgres.Run(ctx, "postgres:16",
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
+		postgres.WithDatabase("integration_tests_db"),
+		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
+			req.Cmd = append(req.Cmd, "-c", "log_statement=all")
+			return nil
+		}),
+	)
+}
+
+func RunPostgresContainerWithTmpfs(ctx context.Context) (*postgres.PostgresContainer, error) {
+	return postgres.Run(
+		ctx,
+		"postgres:16",
+		postgres.WithDatabase("integration_tests_db"),
+		testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
+			hostConfig.Tmpfs = map[string]string{
+				"/var/lib/postgresql/data": "rw",
+			}
+		}),
+		testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = []string{
+				"postgres",
+				"-c", "fsync=off",
+				"-c", "synchronous_commit=off",
+				"-c", "full_page_writes=off",
+				"-c", "shared_buffers=512MB",
+				"-c", "autovacuum=off",
+			}
+		}),
+		testcontainers.WithEnv(map[string]string{
+			"POSTGRES_INITDB_ARGS": "--nosync",
+		}),
+		postgres.BasicWaitStrategies(),
+	)
 }
 
 func (db *containerDB) ConnStr() string {


### PR DESCRIPTION
## Ubuntu 24.04 (Yandex Cloud)

```shell
go test -timeout=30m -p=1 -count=5 ./...
?       github.com/ivagulin/dbmocks/migrations  [no test files]
ok      github.com/ivagulin/dbmocks/pgtestpkg   109.782s
?       github.com/ivagulin/dbmocks/repo        [no test files]
ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        104.616s
ok      github.com/ivagulin/dbmocks/testcontainerspkg   432.450s
?       github.com/ivagulin/dbmocks/testinfra   [no test files]

go test -timeout=30m -p=1 -count=3 ./...
?       github.com/ivagulin/dbmocks/migrations  [no test files]
ok      github.com/ivagulin/dbmocks/pgtestpkg   65.956s
?       github.com/ivagulin/dbmocks/repo        [no test files]
ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        63.031s
ok      github.com/ivagulin/dbmocks/testcontainerspkg   262.272s
?       github.com/ivagulin/dbmocks/testinfra   [no test files]
```

### Окружение

Yandex Cloud:

- OS: Ubuntu 24.04
- CPU: 16 CPU 100%, Intel Ice Lake
- RAM: 32 GiB
- DISK: SSD IO 186 GB (56000/11200 IOPS, 220/164 MB/s)

<details>

<summary>Подробнее</summary>

```shell
lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.2 LTS
Release:        24.04
Codename:       noble

lscpu
Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          40 bits physical, 57 bits virtual
  Byte Order:             Little Endian
CPU(s):                   16
  On-line CPU(s) list:    0-15
Vendor ID:                GenuineIntel
  BIOS Vendor ID:         QEMU
  Model name:             Intel Xeon Processor (Icelake)
    BIOS Model name:      pc-q35-yc-2.12  CPU @ 2.0GHz
    BIOS CPU family:      1
    CPU family:           6
    Model:                106
    Thread(s) per core:   2
    Core(s) per socket:   8
    Socket(s):            1
    Stepping:             0
    BogoMIPS:             3990.63
    Flags:                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma 
                          cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault ssbd ibrs ibpb stibp ibrs_enhanced fsgsbase bmi1 avx2 smep bmi2 erms invpcid avx512f a
                          vx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 wbnoinvd arat avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntd
                          q la57 rdpid fsrm md_clear arch_capabilities
Virtualization features:  
  Hypervisor vendor:      KVM
  Virtualization type:    full
Caches (sum of all):      
  L1d:                    512 KiB (16 instances)
  L1i:                    512 KiB (16 instances)
  L2:                     32 MiB (8 instances)
  L3:                     16 MiB (1 instance)
NUMA:                     
  NUMA node(s):           1
  NUMA node0 CPU(s):      0-15
Vulnerabilities:          
  Gather data sampling:   Not affected
  Itlb multihit:          Not affected
  L1tf:                   Not affected
  Mds:                    Not affected
  Meltdown:               Not affected
  Mmio stale data:        Mitigation; Clear CPU buffers; SMT Host state unknown
  Reg file data sampling: Not affected
  Retbleed:               Not affected
  Spec rstack overflow:   Not affected
  Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
  Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:             Mitigation; Enhanced / Automatic IBRS; IBPB conditional; RSB filling; PBRSB-eIBRS SW sequence; BHI SW loop, KVM SW loop
  Srbds:                  Not affected
  Tsx async abort:        Not affected
  
free -h
               total        used        free      shared  buff/cache   available
Mem:            31Gi       1.3Gi        26Gi       182Mi       4.7Gi        30Gi
Swap:             0B          0B          0B

go version
go version go1.23.10 linux/amd64

docker info
Client: Docker Engine - Community
 Version:    28.3.1
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.25.0
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v2.38.1
    Path:     /usr/libexec/docker/cli-plugins/docker-compose

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 2
 Server Version: 28.3.1
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 05044ec0a9a75232cad458027ca83437aae3f4da
 runc version: v1.2.5-0-g59923ef
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.8.0-62-generic
 Operating System: Ubuntu 24.04.2 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 16
 Total Memory: 31.34GiB
 Name: compute-vm-16-32-186-ssd-io-m3-1751676682773
 ID: 9bac4856-d65a-42b6-9048-367a314948d6
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Live Restore Enabled: false
 
psql --version
psql (PostgreSQL) 16.9 (Ubuntu 16.9-1.pgdg24.04+1)

docker images | grep postgres
postgres              16        f465f4fe2ba0   4 weeks ago    436MB
```

</details>

<details>

<summary>Настройка окружения</summary>

```shell
sudo apt update
sudo apt install -y \
  git \
  wget \
  curl \
  ca-certificates \
  gnupg \
  lsb-release \
  apt-transport-https

#go
rm -rf /usr/local/go
wget https://go.dev/dl/go1.23.10.linux-amd64.tar.gz
sudo tar -C /usr/local -xzf go1.23.10.linux-amd64.tar.gz

echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
source ~/.profile

go version

#docker
for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done

# Add Docker's official GPG key:
sudo apt-get update
sudo apt-get install ca-certificates curl
sudo install -m 0755 -d /etc/apt/keyrings
sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
sudo chmod a+r /etc/apt/keyrings/docker.asc

# Add the repository to Apt sources:
echo \
  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt-get update

sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

docker pull postgres:16

#postgres
sudo apt install -y postgresql-common curl ca-certificates
sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh

sudo apt update
sudo apt install -y postgresql-16 postgresql-client-16 libpq-dev

psql --version
```

</details>

## MacOS

```shell
go test -timeout=30m -p=1 -count=3 ./...
?       github.com/ivagulin/dbmocks/migrations  [no test files]
ok      github.com/ivagulin/dbmocks/pgtestpkg   179.647s
?       github.com/ivagulin/dbmocks/repo        [no test files]
ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        100.401s
ok      github.com/ivagulin/dbmocks/testcontainerspkg   112.284s
?       github.com/ivagulin/dbmocks/testinfra   [no test files]

go test -timeout=30m -p=1 -count=3 ./...
?       github.com/ivagulin/dbmocks/migrations  [no test files]
ok      github.com/ivagulin/dbmocks/pgtestpkg   179.349s
?       github.com/ivagulin/dbmocks/repo        [no test files]
ok      github.com/ivagulin/dbmocks/testcontainers_tmpfs        106.758s
ok      github.com/ivagulin/dbmocks/testcontainerspkg   117.221s
?       github.com/ivagulin/dbmocks/testinfra   [no test files]
```

### Окружение

Apple MacBook Pro 14, M2 Pro, 32 GiB, 512 GB, macOS 13.7.4 (22H420)

<details>

<summary>Подробнее</summary>

```shell
go version
go version go1.23.5 darwin/arm64

docker version
Client:
 Version:           28.0.1
 API version:       1.48
 Go version:        go1.23.6
 Git commit:        068a01e
 Built:             Wed Feb 26 10:38:16 2025
 OS/Arch:           darwin/arm64
 Context:           desktop-linux

Server: Docker Desktop 4.39.0 (184744)
 Engine:
  Version:          28.0.1
  API version:      1.48 (minimum version 1.24)
  Go version:       go1.23.6
  Git commit:       bbd0a17
  Built:            Wed Feb 26 10:40:57 2025
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.7.25
  GitCommit:        bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
 runc:
  Version:          1.2.4
  GitCommit:        v1.2.4-0-g6c52b3f
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
  
postgres --version
postgres (PostgreSQL) 16.9 (Homebrew)
```

</details>
